### PR TITLE
新增功能：“搜索结果过滤”和“导出异常列表”

### DIFF
--- a/Music-Downloader-UI/Json/json.cs
+++ b/Music-Downloader-UI/Json/json.cs
@@ -21,6 +21,7 @@ namespace MusicDownloader.Json
         /// </summary>
         public int SavePathStyle { get; set; }
         public string SearchQuantity { get; set; }
+        public string SearchResultFilter { get; set; }
         /// <summary>
         /// 0 外语; 1 翻译
         /// </summary>

--- a/Music-Downloader-UI/MainWindow.xaml.cs
+++ b/Music-Downloader-UI/MainWindow.xaml.cs
@@ -96,6 +96,7 @@ namespace MusicDownloader
                 SaveNameStyle = int.Parse(Tool.Config.Read("SaveNameStyle") ?? "0"),
                 SavePathStyle = int.Parse(Tool.Config.Read("SavePathStyle") ?? "0"),
                 SearchQuantity = Tool.Config.Read("SearchQuantity") ?? "100",
+                SearchResultFilter=Tool.Config.Read("SearchResultFilter")??"",
                 TranslateLrc = int.Parse(Tool.Config.Read("TranslateLrc") ?? "0"),
                 Api1 = Tool.Config.Read("Source1") ?? "",
                 Api2 = Tool.Config.Read("Source2") ?? "",

--- a/Music-Downloader-UI/Pages/DownloadPage.xaml
+++ b/Music-Downloader-UI/Pages/DownloadPage.xaml
@@ -49,15 +49,17 @@
         </DataGrid>
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="310*"/>
+                <ColumnDefinition Width="230*"/>
                 <ColumnDefinition Width="110*"/>
                 <ColumnDefinition Width="60*"/>
                 <ColumnDefinition Width="100*"/>
+                <ColumnDefinition Width="80*"/>
             </Grid.ColumnDefinitions>
             <Label Content="打开音乐保存路径" Foreground="LightGray" PreviewMouseDown="Label_PreviewMouseDown" Grid.Column="1"/>
             <Label Content="清空列表" Foreground="LightGray" PreviewMouseDown="Label_PreviewMouseDown_1" Grid.Column="2"/>
-            <Label Content="音源1 歌词可能出现无法下载的情况，过段时间再试" Foreground="White" Grid.Column="0" HorizontalAlignment="Center"/>
+            <Label Content="音源1 歌词可能无法下载。稍后再试" Foreground="White" Grid.Column="0" HorizontalAlignment="Center"/>
             <Label Content="清除正常下载项" Foreground="LightGray" PreviewMouseDown="Label_PreviewMouseDown_2" Grid.Column="3"/>
+            <Label Content="导出异常列表" Foreground="LightGray" PreviewMouseDown="Label_PreviewMouseDown_3" Grid.Column="4"/>
         </Grid>
 
     </Grid>

--- a/Music-Downloader-UI/Pages/DownloadPage.xaml.cs
+++ b/Music-Downloader-UI/Pages/DownloadPage.xaml.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -144,6 +145,80 @@ namespace MusicDownloader
             List.ItemsSource = listitem;
             List.Items.Refresh();
         }
+
+        private void Label_PreviewMouseDown_3(object sender, MouseButtonEventArgs e)
+        {
+            if (music.th_Download?.ThreadState == System.Threading.ThreadState.Running)
+            {
+                AduMessageBox.Show("请等待下载完成后再试", "提示", MessageBoxButton.OK);
+                return;
+            }
+
+            string path = @music.setting.SavePath+"\\" + DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss") + ".csv";
+
+            if (save_list_as_csv(path))
+            {
+                Process.Start(path);
+                return;
+            }
+
+            AduMessageBox.Show("导出列表失败", "错误", MessageBoxButton.OK);
+
+        }
+
+
+        private bool save_list_as_csv(string path)
+        {
+            //   string path = @"C:\Users\Unity\Desktop\info.csv";
+
+            try
+            {
+                if (!File.Exists(path))
+                    File.Create(path).Close();
+                StreamWriter sw = new StreamWriter(path, true, Encoding.UTF8);
+
+                //StreamWriter sw = File.CreateText(path);
+
+                sw.Write("Title,Artist,Album,State\r\n");
+      
+
+                for (int i = 0; i < listitem.Count; i++)
+                {
+                    if (listitem[i].State == "下载完成" || listitem[i].State == "音乐已存在")
+                    {
+                        continue;
+                    }
+
+                    string title = listitem[i].Title;
+                    string singer = listitem[i].Singer;
+                    string album = listitem[i].Album;
+
+                    if (title.IndexOf(',') > -1)
+                        sw.Write("\"" + title + "\",");
+                    else
+                        sw.Write(title + ",");
+
+                    if (singer.IndexOf(',') > -1)
+                        sw.Write("\"" + singer + "\",");
+                    else
+                        sw.Write(singer + ",");
+
+                    if (album.IndexOf(',') > -1)
+                        sw.Write("\"" + album + "\",");
+                    else
+                        sw.Write(album + ",");
+
+                    sw.Write(listitem[i].State+"\r\n");
+                } 
+                sw.Flush();
+                sw.Close();
+            }
+            catch {
+                return false;
+            }
+            return true;
+        }
+
         private void menu_Title_Click(object sender, RoutedEventArgs e)
         {
             Clipboard.SetText(listitem[List.SelectedIndex].Title);

--- a/Music-Downloader-UI/Pages/SearchPage.xaml.cs
+++ b/Music-Downloader-UI/Pages/SearchPage.xaml.cs
@@ -403,6 +403,10 @@ namespace MusicDownloader.Pages
                     AduMessageBox.Show("搜索错误", "提示", MessageBoxButton.OK);
                     return;
                 }
+
+                Filter filter = new Filter(setting.SearchResultFilter, key);
+                musicinfo = filter.Filt(musicinfo);
+
                 foreach (MusicInfo m in musicinfo)
                 {
                     SearchListItemModel mod = new SearchListItemModel()
@@ -423,6 +427,66 @@ namespace MusicDownloader.Pages
             {
                 pb.Close();
                 AduMessageBox.Show("搜索错误", "提示", MessageBoxButton.OK);
+            }
+        }
+
+
+
+        // 对搜索结果进行过滤
+
+        public class Filter
+        {
+            private List<string> list;
+
+            public Filter(string filter_string, string search_key)
+            {
+                string[] filter = filter_string.ToLower().Split(new char[] { ' ', '\t', '\n', '\r' });
+
+                list = new List<string>();
+                foreach (string str in filter)
+                {
+                    if (str.Length > 0)
+                    {
+                         list.Add(str);
+                    }
+                     
+                }
+
+                string[] key = search_key.ToLower().Split(new char[] { ' ', '\t', '\n', '\r' });
+
+                foreach (string str in key)
+                {
+                    if (str.Length > 0)
+                    {
+                        list.Remove(str);
+                    }
+
+                }
+            }
+
+            public List<MusicInfo> Filt(List<MusicInfo> infolist)
+            {
+                List<MusicInfo> tmp = new List<MusicInfo>();
+
+                foreach (MusicInfo info in infolist)
+                {
+                    int i = list.Count-1;
+                    for(;i >= 0; i--)
+                    {
+                        string filter = list[i];
+
+                        if (info.Title.ToLower().Contains(filter))
+                            break;
+                        if (info.Singer.ToLower().Contains(filter))
+                            break;
+                    }
+                    if (i == -1)
+                    {
+                   tmp.Add(info);
+                    }
+                }
+
+                return tmp;
             }
         }
 

--- a/Music-Downloader-UI/Pages/SettingPage.xaml
+++ b/Music-Downloader-UI/Pages/SettingPage.xaml
@@ -28,6 +28,10 @@
                     <Label Foreground="White" Content="单次搜索数量"/>
                     <TextBox Foreground="White" Background="#20FFFFFF" BorderThickness="0" InputMethod.IsInputMethodEnabled="False" Name="searchQuantityTextBox" Width="130" Height="25" PreviewKeyDown="searchQuantityTextBox_PreviewKeyDown"/>
                 </WrapPanel>
+                <WrapPanel>
+                    <Label Foreground="White" Margin="0 10 0 0" Content="搜索结果过滤词"/>
+                    <TextBox Foreground="White" Background="#20FFFFFF" BorderThickness="0" Margin="0 10 0 0" Name="searchresultfiltertextbox" Width="280" Height="25" />
+                </WrapPanel>
                 <WrapPanel Margin="0 3 0 0" HorizontalAlignment="Center"/>
                 <WrapPanel Margin="0 10 0 0" HorizontalAlignment="Center">
                     <Label Foreground="White" Content="下载品质" HorizontalAlignment="Left" Height="25"  VerticalAlignment="Top"/>
@@ -35,7 +39,7 @@
                       Style="{StaticResource ComboxTemplate}"
                       Background="#20FFFFFF"
                       pu:ComboBoxHelper.SelectedBackground="#80FFFFFF"
-                      BorderBrush="Transparent" Name="qualityComboBox" Margin="10 0 0 0" HorizontalAlignment="Left" VerticalAlignment="Top" Width="200" Height="25">
+                      BorderBrush="Transparent" Name="qualityComboBox" Margin="10 0 0 0" HorizontalAlignment="Left" VerticalAlignment="Top" Width="230" Height="25">
                         <ComboBoxItem Content="无损(999000)" IsSelected="True" HorizontalAlignment="Left" Width="200" Margin="0,0,-2,0"/>
                         <ComboBoxItem Content="极高(320000)" HorizontalAlignment="Left" Width="200"/>
                         <ComboBoxItem Content="标准(128000)" HorizontalAlignment="Left" Width="200"/>
@@ -46,7 +50,7 @@
                     <ComboBox Name="nameStyleComboBox" Foreground="White" Style="{StaticResource ComboxTemplate}"
                       Background="#20FFFFFF"
                       pu:ComboBoxHelper.SelectedBackground="#80FFFFFF"
-                      BorderBrush="Transparent" Margin="10 0 0 0" HorizontalAlignment="Left" VerticalAlignment="Top" Width="200" Height="25">
+                      BorderBrush="Transparent" Margin="10 0 0 0" HorizontalAlignment="Left" VerticalAlignment="Top" Width="190" Height="25">
                         <ComboBoxItem Content="标题 - 歌手" IsSelected="True" HorizontalAlignment="Left" Width="200" Margin="0,0,-2,0"/>
                         <ComboBoxItem Content="歌手 - 标题" HorizontalAlignment="Left" Width="200"/>
                     </ComboBox>

--- a/Music-Downloader-UI/Pages/SettingPage.xaml.cs
+++ b/Music-Downloader-UI/Pages/SettingPage.xaml.cs
@@ -55,6 +55,7 @@ namespace MusicDownloader.Pages
         {
             savePathTextBox.Text = setting.SavePath;
             searchQuantityTextBox.Text = setting.SearchQuantity;
+            searchresultfiltertextbox.Text = setting.SearchResultFilter;
             switch (setting.DownloadQuality)
             {
                 case "999000":
@@ -108,6 +109,7 @@ namespace MusicDownloader.Pages
                 return;
             }
             Tool.Config.Write("SavePath", savePathTextBox.Text);
+            Tool.Config.Write("SearchResultFilter", searchresultfiltertextbox.Text);
             Tool.Config.Write("DownloadQuality", ((System.Windows.Controls.ContentControl)qualityComboBox.SelectedValue).Content.ToString().Substring(("无损(").Length, 6));
             Tool.Config.Write("IfDownloadLrc", lrcCheckBox.IsChecked.ToString());
             Tool.Config.Write("IfDownloadPic", picCheckBox.IsChecked.ToString());
@@ -151,6 +153,7 @@ namespace MusicDownloader.Pages
             }
             setting.SavePath = savePathTextBox.Text;
             setting.DownloadQuality = ((System.Windows.Controls.ContentControl)qualityComboBox.SelectedValue).Content.ToString().Substring(("无损(").Length, "999000".Length);
+            setting.SearchResultFilter= searchresultfiltertextbox.Text;
             setting.IfDownloadLrc = lrcCheckBox.IsChecked ?? false;
             setting.IfDownloadPic = picCheckBox.IsChecked ?? false;
             setting.SaveNameStyle = nameStyleComboBox.SelectedIndex;


### PR DESCRIPTION
1. 在设置界面增加了“搜索结果过滤”选项，当搜索结果包含过滤的关键词时，该条内容会被自动隐藏。关键词之间使用空字符进行分割。当填入remix cover live 原唱 翻唱 时，可以有效过滤混音、翻唱、live等版本，得到我更偏好的录音室版本。
2.在下载界面增加“导出异常列表”功能。在批量下载失败时，导入失败的任务的csv列表，以便使用其他方式重新下载。